### PR TITLE
Add config option for cluster name

### DIFF
--- a/mesos-master.py
+++ b/mesos-master.py
@@ -21,6 +21,7 @@ import mesos_collectd
 
 IS_MASTER = True
 PREFIX = "mesos-master"
+MESOS_CLUSTER = ""
 MESOS_INSTANCE = ""
 MESOS_HOST = "localhost"
 MESOS_PORT = 5050
@@ -207,8 +208,9 @@ STATS_MESOS_022 = {
 
 
 def configure_callback(conf):
-    mesos_collectd.configure_callback(conf, PREFIX, MESOS_INSTANCE, MESOS_HOST,
-                                      MESOS_PORT, MESOS_VERSION, MESOS_URL,
+    mesos_collectd.configure_callback(conf, PREFIX, MESOS_CLUSTER,
+                                      MESOS_INSTANCE, MESOS_HOST, MESOS_PORT,
+                                      MESOS_VERSION, MESOS_URL,
                                       VERBOSE_LOGGING)
 
 

--- a/mesos-slave.py
+++ b/mesos-slave.py
@@ -21,6 +21,7 @@ import mesos_collectd
 
 IS_MASTER = False
 PREFIX = "mesos-slave"
+MESOS_CLUSTER = ""
 MESOS_INSTANCE = ""
 MESOS_HOST = "localhost"
 MESOS_PORT = 5051
@@ -100,8 +101,9 @@ STATS_MESOS_022 = STATS_MESOS_021.copy()
 
 
 def configure_callback(conf):
-    mesos_collectd.configure_callback(conf, PREFIX, MESOS_INSTANCE, MESOS_HOST,
-                                      MESOS_PORT, MESOS_VERSION, MESOS_URL,
+    mesos_collectd.configure_callback(conf, PREFIX, MESOS_CLUSTER,
+                                      MESOS_INSTANCE, MESOS_HOST, MESOS_PORT,
+                                      MESOS_VERSION, MESOS_URL,
                                       VERBOSE_LOGGING)
 
 


### PR DESCRIPTION
Provide option for user to configure the name of the cluster to which
the node belongs. Send the name in the metric as a "cluster" dimension.
