### PR TITLE
Move duplicated plugin functions into common file

### DIFF
--- a/mesos-master.py
+++ b/mesos-master.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 
 import collectd
-import json
-import urllib2
-import socket
 import collections
 
+import mesos_collectd
+
+
+IS_MASTER = True
 PREFIX = "mesos-master"
 MESOS_INSTANCE = ""
 MESOS_HOST = "localhost"
@@ -26,8 +27,6 @@ MESOS_PORT = 5050
 MESOS_VERSION = "0.22.0"
 MESOS_URL = ""
 VERBOSE_LOGGING = False
-
-CONFIGS = []
 
 Stat = collections.namedtuple('Stat', ('type', 'path'))
 
@@ -44,33 +43,54 @@ STATS_MESOS = {
     'master/elected': Stat("gauge", "master/elected"),
     'master/frameworks_active': Stat("gauge", "master/frameworks_active"),
     'master/frameworks_inactive': Stat("gauge", "master/frameworks_inactive"),
-    'master/invalid_framework_to_executor_messages': Stat("counter", "master/invalid_framework_to_executor_messages"),
-    'master/invalid_status_update_acknowledgements': Stat("counter", "master/invalid_status_update_acknowledgements"),
-    'master/invalid_status_updates': Stat("counter", "master/invalid_status_updates"),
+    'master/invalid_framework_to_executor_messages':
+        Stat("counter", "master/invalid_framework_to_executor_messages"),
+    'master/invalid_status_update_acknowledgements':
+        Stat("counter", "master/invalid_status_update_acknowledgements"),
+    'master/invalid_status_updates':
+        Stat("counter", "master/invalid_status_updates"),
     'master/mem_percent': Stat("percent", "master/mem_percent"),
     'master/mem_total': Stat("gauge", "master/mem_total"),
     'master/mem_used': Stat("gauge", "master/mem_used"),
-    'master/messages_authenticate': Stat("counter", "master/messages_authenticate"),
-    'master/messages_deactivate_framework': Stat("counter", "master/messages_deactivate_framework"),
-    'master/messages_exited_executor': Stat("counter", "master/messages_exited_executor"),
-    'master/messages_framework_to_executor': Stat("counter", "master/messages_framework_to_executor"),
+    'master/messages_authenticate':
+        Stat("counter", "master/messages_authenticate"),
+    'master/messages_deactivate_framework':
+        Stat("counter", "master/messages_deactivate_framework"),
+    'master/messages_exited_executor':
+        Stat("counter", "master/messages_exited_executor"),
+    'master/messages_framework_to_executor':
+        Stat("counter", "master/messages_framework_to_executor"),
     'master/messages_kill_task': Stat("counter", "master/messages_kill_task"),
-    'master/messages_launch_tasks': Stat("counter", "master/messages_launch_tasks"),
-    'master/messages_reconcile_tasks': Stat("counter", "master/messages_reconcile_tasks"),
-    'master/messages_register_framework': Stat("counter", "master/messages_register_framework"),
-    'master/messages_register_slave': Stat("counter", "master/messages_register_slave"),
-    'master/messages_reregister_framework': Stat("counter", "master/messages_reregister_framework"),
-    'master/messages_reregister_slave': Stat("counter", "master/messages_reregister_slave"),
-    'master/messages_revive_offers': Stat("counter", "master/messages_revive_offers"),
-    'master/messages_status_update': Stat("counter", "master/messages_status_update"),
-    'master/messages_status_update_acknowledgement': Stat("counter", "master/messages_status_update_acknowledgement"),
-    'master/messages_unregister_framework': Stat("counter", "master/messages_unregister_framework"),
-    'master/messages_unregister_slave': Stat("counter", "master/messages_unregister_slave"),
+    'master/messages_launch_tasks':
+        Stat("counter", "master/messages_launch_tasks"),
+    'master/messages_reconcile_tasks':
+        Stat("counter", "master/messages_reconcile_tasks"),
+    'master/messages_register_framework':
+        Stat("counter", "master/messages_register_framework"),
+    'master/messages_register_slave':
+        Stat("counter", "master/messages_register_slave"),
+    'master/messages_reregister_framework':
+        Stat("counter", "master/messages_reregister_framework"),
+    'master/messages_reregister_slave':
+        Stat("counter", "master/messages_reregister_slave"),
+    'master/messages_revive_offers':
+        Stat("counter", "master/messages_revive_offers"),
+    'master/messages_status_update':
+        Stat("counter", "master/messages_status_update"),
+    'master/messages_status_update_acknowledgement':
+        Stat("counter", "master/messages_status_update_acknowledgement"),
+    'master/messages_unregister_framework':
+        Stat("counter", "master/messages_unregister_framework"),
+    'master/messages_unregister_slave':
+        Stat("counter", "master/messages_unregister_slave"),
     'master/outstanding_offers': Stat("gauge", "master/outstanding_offers"),
-    'master/recovery_slave_removals': Stat("counter", "master/recovery_slave_removals"),
-    'master/slave_registrations': Stat("counter", "master/slave_registrations"),
+    'master/recovery_slave_removals':
+        Stat("counter", "master/recovery_slave_removals"),
+    'master/slave_registrations':
+        Stat("counter", "master/slave_registrations"),
     'master/slave_removals': Stat("counter", "master/slave_removals"),
-    'master/slave_reregistrations': Stat("counter", "master/slave_reregistrations"),
+    'master/slave_reregistrations':
+        Stat("counter", "master/slave_reregistrations"),
     'master/slaves_active': Stat("gauge", "master/slaves_active"),
     'master/slaves_inactive': Stat("gauge", "master/slaves_inactive"),
     'master/tasks_failed': Stat("counter", "master/tasks_failed"),
@@ -81,24 +101,38 @@ STATS_MESOS = {
     'master/tasks_staging': Stat("gauge", "master/tasks_staging"),
     'master/tasks_starting': Stat("gauge", "master/tasks_starting"),
     'master/uptime_secs': Stat("gauge", "master/uptime_secs"),
-    'master/valid_framework_to_executor_messages': Stat("counter", "master/valid_framework_to_executor_messages"),
-    'master/valid_status_update_acknowledgements': Stat("counter", "master/valid_status_update_acknowledgements"),
-    'master/valid_status_updates': Stat("counter", "master/valid_status_updates"),
+    'master/valid_framework_to_executor_messages':
+        Stat("counter", "master/valid_framework_to_executor_messages"),
+    'master/valid_status_update_acknowledgements':
+        Stat("counter", "master/valid_status_update_acknowledgements"),
+    'master/valid_status_updates':
+        Stat("counter", "master/valid_status_updates"),
 
     # Registrar
-    'registrar/queued_operations': Stat("gauge", "registrar/queued_operations"),
-    'registrar/registry_size_bytes': Stat("bytes", "registrar/registry_size_bytes"),
+    'registrar/queued_operations':
+        Stat("gauge", "registrar/queued_operations"),
+    'registrar/registry_size_bytes':
+        Stat("bytes", "registrar/registry_size_bytes"),
     'registrar/state_fetch_ms': Stat("gauge", "registrar/state_fetch_ms"),
     'registrar/state_store_ms': Stat("gauge", "registrar/state_store_ms"),
-    'registrar/state_store_ms/count': Stat("gauge", "registrar/state_store_ms/count"),
-    'registrar/state_store_ms/max': Stat("gauge", "registrar/state_store_ms/max"),
-    'registrar/state_store_ms/min': Stat("gauge", "registrar/state_store_ms/min"),
-    'registrar/state_store_ms/p50': Stat("gauge", "registrar/state_store_ms/p50"),
-    'registrar/state_store_ms/p90': Stat("gauge", "registrar/state_store_ms/p90"),
-    'registrar/state_store_ms/p95': Stat("gauge", "registrar/state_store_ms/p95"),
-    'registrar/state_store_ms/p99': Stat("gauge", "registrar/state_store_ms/p99"),
-    'registrar/state_store_ms/p999': Stat("gauge", "registrar/state_store_ms/p999"),
-    'registrar/state_store_ms/p9999': Stat("gauge", "registrar/state_store_ms/p9999"),
+    'registrar/state_store_ms/count':
+        Stat("gauge", "registrar/state_store_ms/count"),
+    'registrar/state_store_ms/max':
+        Stat("gauge", "registrar/state_store_ms/max"),
+    'registrar/state_store_ms/min':
+        Stat("gauge", "registrar/state_store_ms/min"),
+    'registrar/state_store_ms/p50':
+        Stat("gauge", "registrar/state_store_ms/p50"),
+    'registrar/state_store_ms/p90':
+        Stat("gauge", "registrar/state_store_ms/p90"),
+    'registrar/state_store_ms/p95':
+        Stat("gauge", "registrar/state_store_ms/p95"),
+    'registrar/state_store_ms/p99':
+        Stat("gauge", "registrar/state_store_ms/p99"),
+    'registrar/state_store_ms/p999':
+        Stat("gauge", "registrar/state_store_ms/p999"),
+    'registrar/state_store_ms/p9999':
+        Stat("gauge", "registrar/state_store_ms/p9999"),
 
     # Elected Master System Metrics
     'system/cpus_total': Stat("gauge", "system/cpus_total"),
@@ -116,159 +150,73 @@ STATS_MESOS_019 = {
 
 # DICT: Mesos 0.20.0, 0.20.1
 STATS_MESOS_020 = {
-    'master/event_queue_dispatches': Stat("gauge", "master/event_queue_dispatches"),
-    'master/event_queue_http_requests': Stat("gauge", "master/event_queue_http_requests"),
-    'master/event_queue_messages': Stat("gauge", "master/event_queue_messages"),
-    'master/messages_resource_request': Stat("counter", "master/messages_resource_request")
+    'master/event_queue_dispatches':
+        Stat("gauge", "master/event_queue_dispatches"),
+    'master/event_queue_http_requests':
+        Stat("gauge", "master/event_queue_http_requests"),
+    'master/event_queue_messages':
+        Stat("gauge", "master/event_queue_messages"),
+    'master/messages_resource_request':
+        Stat("counter", "master/messages_resource_request")
 }
 
 # DICT: Mesos 0.21.0, 0.21.1
 STATS_MESOS_021 = {
-    'master/event_queue_dispatches': Stat("gauge", "master/event_queue_dispatches"),
-    'master/event_queue_http_requests': Stat("gauge", "master/event_queue_http_requests"),
-    'master/event_queue_messages': Stat("gauge", "master/event_queue_messages"),
-    'master/frameworks_connected': Stat("gauge", "master/frameworks_connected"),
-    'master/frameworks_disconnected': Stat("gauge", "master/frameworks_disconnected"),
-    'master/messages_resource_request': Stat("counter", "master/messages_resource_request"),
+    'master/event_queue_dispatches':
+        Stat("gauge", "master/event_queue_dispatches"),
+    'master/event_queue_http_requests':
+        Stat("gauge", "master/event_queue_http_requests"),
+    'master/event_queue_messages':
+        Stat("gauge", "master/event_queue_messages"),
+    'master/frameworks_connected':
+        Stat("gauge", "master/frameworks_connected"),
+    'master/frameworks_disconnected':
+        Stat("gauge", "master/frameworks_disconnected"),
+    'master/messages_resource_request':
+        Stat("counter", "master/messages_resource_request"),
     'master/slaves_connected': Stat("gauge", "master/slaves_connected"),
     'master/slaves_disconnected': Stat("gauge", "master/slaves_disconnected")
 }
 
 # DICT: Mesos 0.22.0, 0.22.1
 STATS_MESOS_022 = {
-    'master/event_queue_dispatches': Stat("gauge", "master/event_queue_dispatches"),
-    'master/event_queue_http_requests': Stat("gauge", "master/event_queue_http_requests"),
-    'master/event_queue_messages': Stat("gauge", "master/event_queue_messages"),
-    'master/frameworks_connected': Stat("gauge", "master/frameworks_connected"),
-    'master/frameworks_disconnected': Stat("gauge", "master/frameworks_disconnected"),
-    'master/messages_decline_offers': Stat("counter", "master/messages_decline_offers"),
-    'master/messages_resource_request': Stat("counter", "master/messages_resource_request"),
+    'master/event_queue_dispatches':
+        Stat("gauge", "master/event_queue_dispatches"),
+    'master/event_queue_http_requests':
+        Stat("gauge", "master/event_queue_http_requests"),
+    'master/event_queue_messages':
+        Stat("gauge", "master/event_queue_messages"),
+    'master/frameworks_connected':
+        Stat("gauge", "master/frameworks_connected"),
+    'master/frameworks_disconnected':
+        Stat("gauge", "master/frameworks_disconnected"),
+    'master/messages_decline_offers':
+        Stat("counter", "master/messages_decline_offers"),
+    'master/messages_resource_request':
+        Stat("counter", "master/messages_resource_request"),
     'master/slaves_connected': Stat("gauge", "master/slaves_connected"),
     'master/slaves_disconnected': Stat("gauge", "master/slaves_disconnected"),
-    'master/slave_shutdowns_canceled': Stat("counter", "master/slave_shutdowns_canceled"),
-    'master/slave_shutdowns_scheduled': Stat("counter", "master/slave_shutdowns_scheduled"),
-    'master/task_lost/source_master/reason_slave_removed': Stat("counter", "task_lost/source_master/reason_slave_removed"),
+    'master/slave_shutdowns_canceled':
+        Stat("counter", "master/slave_shutdowns_canceled"),
+    'master/slave_shutdowns_scheduled':
+        Stat("counter", "master/slave_shutdowns_scheduled"),
+    'master/task_lost/source_master/reason_slave_removed':
+        Stat("counter", "task_lost/source_master/reason_slave_removed"),
     'master/tasks_error': Stat("counter", "master/tasks_error")
 }
 
-# FUNCTION: gets the list of stats based on the version of mesos
-def get_stats_string(version):
-    if version == "0.19.0" or version == "0.19.1":
-       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_019.items())
-    elif version == "0.20.0" or version == "0.20.1":
-       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_020.items())
-    elif version == "0.21.0" or version == "0.21.1":
-       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_021.items())
-    elif version == "0.22.0" or version == "0.22.1":
-       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_022.items())
-    else:
-       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_022.items())
-
-    return stats_cur
-
-# FUNCTION: Collect stats from JSON result
-def lookup_stat(stat, json, conf):
-    val = dig_it_up(json, get_stats_string(conf['version'])[stat].path)
-
-    # Check to make sure we have a valid result
-    # dig_it_up returns False if no match found
-    if not isinstance(val, bool):
-        return val
-    else:
-        return None
-
 
 def configure_callback(conf):
-    """Received configuration information"""
-    host = MESOS_HOST
-    port = MESOS_PORT
-    verboseLogging = VERBOSE_LOGGING
-    version = MESOS_VERSION
-    instance = MESOS_INSTANCE
-    for node in conf.children:
-        if node.key == 'Host':
-            host = node.values[0]
-        elif node.key == 'Port':
-            port = int(node.values[0])
-        elif node.key == 'Verbose':
-            verboseLogging = bool(node.values[0])
-        elif node.key == 'Version':
-            version = node.values[0]
-        elif node.key == 'Instance':
-            instance = node.values[0]
-        else:
-            collectd.warning('mesos-master plugin: Unknown config key: %s.' % node.key)
-            continue
-
-    log_verbose(verboseLogging,'mesos-master plugin configured with host = %s, port = %s, verbose logging = %s, version = %s, instance = %s' % (host,port,verboseLogging,version,instance))
-    CONFIGS.append({
-        'host': host,
-        'port': port,
-        'mesos_url': "http://" + host + ":" + str(port) + "/metrics/snapshot",
-        'verboseLogging': verboseLogging,
-        'version': version,
-        'instance': instance,
-    })
-
-def fetch_stats():
-    for conf in CONFIGS:
-      try:
-          result = json.load(urllib2.urlopen(conf['mesos_url'], timeout=10))
-      except urllib2.URLError, e:
-          collectd.error('mesos-master plugin: Error connecting to %s - %r' % (conf['mesos_url'], e))
-          return None
-      parse_stats(conf, result)
-
-
-def parse_stats(conf, json):
-    """Parse stats response from Mesos"""
-    """Ignore stats if coming from non-leading mesos master"""
-    elected_result = lookup_stat('master/elected', json, conf)
-    if elected_result == 1:
-        for name, key in get_stats_string(conf['version']).iteritems():
-            result = lookup_stat(name, json, conf)
-            dispatch_stat(result, name, key, conf)
-    else:
-        log_verbose(conf['verboseLogging'], 'This mesos master node is not elected leader so not writing data.')
-        return None
-
-
-def dispatch_stat(result, name, key, conf):
-    """Read a key from info response data and dispatch a value"""
-    if result is None:
-        log_verbose(conf['verboseLogging'], 'mesos-master plugin: Value not found for %s' % (name))
-        return
-    estype = key.type
-    value = result
-    log_verbose(conf['verboseLogging'], 'Sending value[%s]: %s=%s for instance:%s' % (estype, name, value, conf['instance']))
-
-    val = collectd.Values(plugin='mesos')
-    val.type = estype
-    val.type_instance = name
-    val.values = [value]
-    val.plugin_instance = conf['instance']
-    # https://github.com/collectd/collectd/issues/716
-    val.meta = {'0': True}
-    val.dispatch()
+    mesos_collectd.configure_callback(conf, PREFIX, MESOS_INSTANCE, MESOS_HOST,
+                                      MESOS_PORT, MESOS_VERSION, MESOS_URL,
+                                      VERBOSE_LOGGING)
 
 
 def read_callback():
-    stats = fetch_stats()
+    mesos_collectd.read_callback(IS_MASTER, STATS_MESOS, STATS_MESOS_019,
+                                 STATS_MESOS_020, STATS_MESOS_021,
+                                 STATS_MESOS_022)
 
-
-def dig_it_up(obj, path):
-    try:
-        if type(path) in (str, unicode):
-            path = path.split('.')
-        return reduce(lambda x, y: x[y], path, obj)
-    except:
-        return False
-
-
-def log_verbose(enabled, msg):
-    if not enabled:
-        return
-    collectd.info('mesos-master plugin [verbose]: %s' % msg)
 
 collectd.register_config(configure_callback)
 collectd.register_read(read_callback)

--- a/mesos-slave.py
+++ b/mesos-slave.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 
 import collectd
-import json
-import urllib2
-import socket
 import collections
 
+import mesos_collectd
+
+
+IS_MASTER = False
 PREFIX = "mesos-slave"
 MESOS_INSTANCE = ""
 MESOS_HOST = "localhost"
@@ -27,16 +28,16 @@ MESOS_VERSION = "0.22.0"
 MESOS_URL = ""
 VERBOSE_LOGGING = False
 
-CONFIGS = []
-
 Stat = collections.namedtuple('Stat', ('type', 'path'))
 
 # DICT: Common Metrics in 0.19.0, 0.20.0, 0.21.0, 0.22.0 and 0.23.0
 STATS_MESOS = {
     # Slave
     'slave/frameworks_active': Stat("gauge", "slave/frameworks_active"),
-    'slave/invalid_framework_messages': Stat("counter", "slave/invalid_framework_messages"),
-    'slave/invalid_status_updates': Stat("counter", "slave/invalid_status_updates"),
+    'slave/invalid_framework_messages':
+        Stat("counter", "slave/invalid_framework_messages"),
+    'slave/invalid_status_updates':
+        Stat("counter", "slave/invalid_status_updates"),
     'slave/recovery_errors': Stat("counter", "slave/recovery_errors"),
     'slave/registered': Stat("gauge", "slave/registered"),
     'slave/tasks_failed': Stat("counter", "slave/tasks_failed"),
@@ -47,8 +48,10 @@ STATS_MESOS = {
     'slave/tasks_starting': Stat("gauge", "slave/tasks_starting"),
     'slave/tasks_staging': Stat("gauge", "slave/tasks_staging"),
     'slave/uptime_secs': Stat("gauge", "slave/uptime_secs"),
-    'slave/valid_framework_messages': Stat("counter", "slave/valid_framework_messages"),
-    'slave/valid_status_updates': Stat("counter", "slave/valid_status_updates"),
+    'slave/valid_framework_messages':
+        Stat("counter", "slave/valid_framework_messages"),
+    'slave/valid_status_updates':
+        Stat("counter", "slave/valid_status_updates"),
 
     # System
     'system/cpus_total': Stat("gauge", "system/cpus_total"),
@@ -65,9 +68,11 @@ STATS_MESOS_019 = {
 
 # DICT: Mesos 0.20.0, 0.20.1
 STATS_MESOS_020 = {
-    'slave/executors_registering': Stat("gauge", "slave/executors_registering"),
+    'slave/executors_registering':
+        Stat("gauge", "slave/executors_registering"),
     'slave/executors_running': Stat("gauge", "slave/executors_running"),
-    'slave/executors_terminating': Stat("gauge", "slave/executors_terminating"),
+    'slave/executors_terminating':
+        Stat("gauge", "slave/executors_terminating"),
     'slave/executors_terminated': Stat("counter", "slave/executors_terminated")
 }
 
@@ -82,128 +87,29 @@ STATS_MESOS_021 = {
     'slave/mem_percent': Stat("percent", "slave/mem_percent"),
     'slave/mem_total': Stat("gauge", "slave/mem_total"),
     'slave/mem_used': Stat("gauge", "slave/mem_used"),
-    'slave/executors_registering': Stat("gauge", "slave/executors_registering"),
+    'slave/executors_registering':
+        Stat("gauge", "slave/executors_registering"),
     'slave/executors_running': Stat("gauge", "slave/executors_running"),
-    'slave/executors_terminating': Stat("gauge", "slave/executors_terminating"),
+    'slave/executors_terminating':
+        Stat("gauge", "slave/executors_terminating"),
     'slave/executors_terminated': Stat("counter", "slave/executors_terminated")
 }
 
 # DICT: Mesos 0.22.0, 0.22.1
 STATS_MESOS_022 = STATS_MESOS_021.copy()
 
-# FUNCTION: gets the list of stats based on the version of mesos
-def get_stats_string(version):
-    if version == "0.19.0" or version == "0.19.1":
-       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_019.items())
-    elif version == "0.20.0" or version == "0.20.1":
-       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_020.items())
-    elif version == "0.21.0" or version == "0.21.1":
-       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_021.items())
-    elif version == "0.22.0" or version == "0.22.1":
-       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_022.items())
-    else:
-       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_022.items())
-
-    return stats_cur
-
-# FUNCTION: Collect stats from JSON result
-def lookup_stat(stat, json, conf):
-    val = dig_it_up(json, get_stats_string(conf['version'])[stat].path)
-
-    # Check to make sure we have a valid result
-    # dig_it_up returns False if no match found
-    if not isinstance(val, bool):
-        return val
-    else:
-        return None
-
 
 def configure_callback(conf):
-    """Received configuration information"""
-    host = MESOS_HOST
-    port = MESOS_PORT
-    verboseLogging = VERBOSE_LOGGING
-    version = MESOS_VERSION
-    instance = MESOS_INSTANCE
-    for node in conf.children:
-        if node.key == 'Host':
-            host = node.values[0]
-        elif node.key == 'Port':
-            port = int(node.values[0])
-        elif node.key == 'Verbose':
-            verboseLogging = bool(node.values[0])
-        elif node.key == 'Version':
-            version = node.values[0]
-        elif node.key == 'Instance':
-            instance = node.values[0]
-        else:
-            collectd.warning('mesos-slave plugin: Unknown config key: %s.' % node.key)
-            continue
-
-    log_verbose(verboseLogging,'mesos-slave plugin configured with host = %s, port = %s, verbose logging = %s, version = %s, instance = %s' % (host,port,verboseLogging,version,instance))
-    CONFIGS.append({
-        'host': host,
-        'port': port,
-        'mesos_url': "http://" + host + ":" + str(port) + "/metrics/snapshot",
-        'verboseLogging': verboseLogging,
-        'version': version,
-        'instance': instance,
-    })
-
-def fetch_stats(conf):
-    try:
-        result = json.load(urllib2.urlopen(conf['mesos_url'], timeout=10))
-    except urllib2.URLError, e:
-        collectd.error('mesos-slave plugin: Error connecting to %s - %r' % (conf['mesos_url'], e))
-        return None
-    parse_stats(conf, result)
-
-
-def parse_stats(conf, json):
-    """Parse stats response from Mesos slave"""
-    for name, key in get_stats_string(conf['version']).iteritems():
-        result = lookup_stat(name, json, conf)
-        dispatch_stat(result, name, key, conf)
-
-
-def dispatch_stat(result, name, key, conf):
-    """Read a key from info response data and dispatch a value"""
-    if result is None:
-        log_verbose(conf['verboseLogging'], 'mesos-master plugin: Value not found for %s' % (name))
-        return
-    estype = key.type
-    value = result
-    log_verbose(conf['verboseLogging'], 'Sending value[%s]: %s=%s for instance:%s' % (estype, name, value, conf['instance']))
-
-    val = collectd.Values(plugin='mesos')
-    val.type = estype
-    val.type_instance = name
-    val.values = [value]
-    val.plugin_instance = conf['instance']
-    # https://github.com/collectd/collectd/issues/716
-    val.meta = {'0': True}
-    val.dispatch()
+    mesos_collectd.configure_callback(conf, PREFIX, MESOS_INSTANCE, MESOS_HOST,
+                                      MESOS_PORT, MESOS_VERSION, MESOS_URL,
+                                      VERBOSE_LOGGING)
 
 
 def read_callback():
-    for conf in CONFIGS:
-        log_verbose(conf['verboseLogging'], 'Read callback called')
-        stats = fetch_stats(conf)
+    mesos_collectd.read_callback(IS_MASTER, STATS_MESOS, STATS_MESOS_019,
+                                 STATS_MESOS_020, STATS_MESOS_021,
+                                 STATS_MESOS_022)
 
-
-def dig_it_up(obj, path):
-    try:
-        if type(path) in (str, unicode):
-            path = path.split('.')
-        return reduce(lambda x, y: x[y], path, obj)
-    except:
-        return False
-
-
-def log_verbose(enabled, msg):
-    if not enabled:
-        return
-    collectd.info('mesos-slave plugin [verbose]: %s' % msg)
 
 collectd.register_config(configure_callback)
 collectd.register_read(read_callback)

--- a/mesos_collectd.py
+++ b/mesos_collectd.py
@@ -1,0 +1,173 @@
+#! /usr/bin/python
+#
+# Common functions for master and slave plugins.
+
+import collectd
+import json
+import urllib2
+
+
+CONFIGS = []
+
+
+# FUNCTION: gets the list of stats based on the version of mesos
+def get_stats_string(version):
+    if version == "0.19.0" or version == "0.19.1":
+       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_019.items())
+    elif version == "0.20.0" or version == "0.20.1":
+       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_020.items())
+    elif version == "0.21.0" or version == "0.21.1":
+       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_021.items())
+    elif version == "0.22.0" or version == "0.22.1":
+       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_022.items())
+    else:
+       stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_022.items())
+
+    return stats_cur
+
+
+# FUNCTION: Collect stats from JSON result
+def lookup_stat(stat, json, conf):
+    val = dig_it_up(json, get_stats_string(conf['version'])[stat].path)
+
+    # Check to make sure we have a valid result
+    # dig_it_up returns False if no match found
+    if not isinstance(val, bool):
+        return val
+    else:
+        return None
+
+
+def configure_callback(conf, prefix, instance, host, port, version, url,
+                       verboseLogging):
+    """Received configuration information"""
+    global MESOS_PREFIX
+    MESOS_PREFIX = prefix
+    global MESOS_INSTANCE
+    MESOS_INSTANCE = instance
+    global MESOS_HOST
+    MESOS_HOST = host
+    global MESOS_PORT
+    MESOS_PORT = port
+    global MESOS_VERSION
+    MESOS_VERSION = version
+    global MESOS_URL
+    MESOS_URL = url
+    global VERBOSE_LOGGING
+    VERBOSE_LOGGING = verboseLogging
+
+    for node in conf.children:
+        if node.key == 'Host':
+            host = node.values[0]
+        elif node.key == 'Port':
+            port = int(node.values[0])
+        elif node.key == 'Verbose':
+            verboseLogging = bool(node.values[0])
+        elif node.key == 'Version':
+            version = node.values[0]
+        elif node.key == 'Instance':
+            instance = node.values[0]
+        else:
+            collectd.warning('%s plugin: Unknown config key: %s.' %
+                             (prefix, node.key))
+            continue
+
+    log_verbose(verboseLogging,
+                '%s plugin configured with host = %s, port = %s, verbose '
+                'logging = %s, version = %s, instance = %s' %
+                (prefix, host, port, verboseLogging, version, instance))
+    CONFIGS.append({
+        'host': host,
+        'port': port,
+        'mesos_url': "http://" + host + ":" + str(port) + "/metrics/snapshot",
+        'verboseLogging': verboseLogging,
+        'version': version,
+        'instance': instance,
+    })
+
+
+def fetch_stats(conf):
+    try:
+        result = json.load(urllib2.urlopen(conf['mesos_url'], timeout=10))
+    except urllib2.URLError, e:
+        collectd.error('%s plugin: Error connecting to %s - %r' %
+                       (prefix, conf['mesos_url'], e))
+        return None
+    parse_stats(conf, result)
+
+
+def parse_stats(conf, json):
+    """Parse stats response from Mesos"""
+    if IS_MASTER:
+        # Ignore stats if coming from non-leading mesos master
+        elected_result = lookup_stat('master/elected', json, conf)
+        if elected_result == 1:
+            for name, key in get_stats_string(conf['version']).iteritems():
+                result = lookup_stat(name, json, conf)
+                dispatch_stat(result, name, key, conf)
+        else:
+            log_verbose(conf['verboseLogging'],
+                        'This mesos master node is not elected leader so not '
+                        'writing data.')
+            return None
+    else:
+        for name, key in get_stats_string(conf['version']).iteritems():
+            result = lookup_stat(name, json, conf)
+            dispatch_stat(result, name, key, conf)
+
+
+def dispatch_stat(result, name, key, conf):
+    """Read a key from info response data and dispatch a value"""
+    if result is None:
+        log_verbose(conf['verboseLogging'],
+                    '%s plugin: Value not found for %s' % (prefix, name))
+        return
+    estype = key.type
+    value = result
+    log_verbose(conf['verboseLogging'],
+                'Sending value[%s]: %s=%s for instance:%s' %
+                (estype, name, value, conf['instance']))
+
+    val = collectd.Values(plugin='mesos')
+    val.type = estype
+    val.type_instance = name
+    val.values = [value]
+    val.plugin_instance = conf['instance']
+    # https://github.com/collectd/collectd/issues/716
+    val.meta = {'0': True}
+    val.dispatch()
+
+
+def read_callback(is_master, stats_mesos, stats_mesos_019, stats_mesos_020,
+                  stats_mesos_021, stats_mesos_022):
+    global IS_MASTER
+    IS_MASTER = is_master
+    global STATS_MESOS
+    STATS_MESOS = stats_mesos
+    global STATS_MESOS_019
+    STATS_MESOS_019 = stats_mesos_019
+    global STATS_MESOS_020
+    STATS_MESOS_020 = stats_mesos_020
+    global STATS_MESOS_021
+    STATS_MESOS_021 = stats_mesos_021
+    global STATS_MESOS_022
+    STATS_MESOS_022 = stats_mesos_022
+
+    for conf in CONFIGS:
+        log_verbose(conf['verboseLogging'], 'Read callback called')
+        stats = fetch_stats(conf)
+
+
+def dig_it_up(obj, path):
+    try:
+        if type(path) in (str, unicode):
+            path = path.split('.')
+        return reduce(lambda x, y: x[y], path, obj)
+    except:
+        return False
+
+
+def log_verbose(enabled, msg):
+    if not enabled:
+        return
+    collectd.info('%s plugin [verbose]: %s' % (prefix, msg))


### PR DESCRIPTION
Refactor plugins to share common functions instead of duplicating code.
Also limit line length to 79 characters, per PEP 8.
