### PR TITLE
Change plugin name and add plugin_type dimension

### DIFF
--- a/mesos_collectd.py
+++ b/mesos_collectd.py
@@ -134,14 +134,16 @@ def dispatch_stat(result, name, key, conf):
                 'Sending value[%s]: %s=%s for instance:%s' %
                 (estype, name, value, conf['instance']))
 
-    val = collectd.Values(plugin=PREFIX)
+    val = collectd.Values(plugin='mesos')
     val.type = estype
     val.type_instance = name
     val.values = [value]
+    plugin_type = 'master' if IS_MASTER else 'slave'
     cluster_dimension = ''
     if conf['cluster']:
-        cluster_dimension = '[cluster=%s]' % conf['cluster']
-    val.plugin_instance = '%s%s' % (conf['instance'], cluster_dimension)
+        cluster_dimension = ',cluster=%s' % conf['cluster']
+    val.plugin_instance = ('%s[plugin_type=%s%s]' %
+                           (conf['instance'], plugin_type, cluster_dimension))
     # https://github.com/collectd/collectd/issues/716
     val.meta = {'0': True}
     val.dispatch()


### PR DESCRIPTION
Turns out that it is useful to have "mesos" be the plugin name for both
masters and slaves, to get both types with one filter. Add a new
dimension named "plugin_type" that specifies whether the plugin is being
used for a master or slave.
