### PR TITLE
Remove second slave from example collectd config

### DIFF
--- a/10-mesos-slave.conf
+++ b/10-mesos-slave.conf
@@ -32,11 +32,4 @@
     Port %%%SLAVE_0_PORT%%%
     Verbose false
   </Module>
-  <Module "mesos-slave">
-    Cluster "cluster-0"
-    Instance "slave-1"
-    Host "%%%SLAVE_IP%%%"
-    Port %%%SLAVE_1_PORT%%%
-    Verbose false
-  </Module>
 </Plugin>


### PR DESCRIPTION
In practice, it doesn't make sense to have more than one slave running
on the same host, since the same resources would be shared among the
slaves.
