### PR TITLE
Add config for path to mesos-master/slave binary

### DIFF
--- a/10-mesos-master.conf
+++ b/10-mesos-master.conf
@@ -15,6 +15,10 @@
 # Config file modifications:
 #   Replace %%%MASTER_IP%%% with the IP address or hostname of the master
 #   and %%%MASTER_PORT%%% with the port on which the master is listening.
+#
+#   Modify Cluster to the name of the cluster to which the Mesos instance
+#   belongs, Instance to the name of this Mesos master instance, and Path
+#   to the location of the mesos-master binary, as needed.
 
 <LoadPlugin "python">
   Globals true
@@ -28,6 +32,7 @@
   <Module "mesos-master">
     Cluster "cluster-0"
     Instance "master-0"
+    Path "/usr/sbin"
     Host "%%%MASTER_IP%%%"
     Port %%%MASTER_PORT%%%
     Verbose false

--- a/10-mesos-slave.conf
+++ b/10-mesos-slave.conf
@@ -15,6 +15,10 @@
 # Config file modifications:
 #   Replace %%%SLAVE_IP%%% with the IP address or hostname of the slave
 #   and %%%SLAVE_PORT%%% with the port on which the slave is listening.
+#
+#   Modify Cluster to the name of the cluster to which the Mesos instance
+#   belongs, Instance to the name of this Mesos slave instance, and Path
+#   to the location of the mesos-slave binary, as needed.
 
 <LoadPlugin "python">
   Globals true
@@ -28,6 +32,7 @@
   <Module "mesos-slave">
     Cluster "cluster-0"
     Instance "slave-0"
+    Path "/usr/sbin"
     Host "%%%SLAVE_IP%%%"
     Port %%%SLAVE_PORT%%%
     Verbose false

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Configuration
  * In the appropriate plugin configuration file (master or slave), change ModulePath to the location where the plugin was downloaded.
  * Change Cluster to a name for the Mesos cluster.
  * Change Instance to a name that will identify the plugin instance.
+ * Change Path to the location of the mesos-master or mesos-slave binary.
  * Set the Host and Port values.
  * Place the configuration file in a location that collectd is aware of.
 

--- a/mesos-master.py
+++ b/mesos-master.py
@@ -21,8 +21,9 @@ import mesos_collectd
 
 IS_MASTER = True
 PREFIX = "mesos-master"
-MESOS_CLUSTER = ""
-MESOS_INSTANCE = ""
+MESOS_CLUSTER = "cluster-0"
+MESOS_INSTANCE = "master-0"
+MESOS_PATH = "/usr/sbin"
 MESOS_HOST = "localhost"
 MESOS_PORT = 5050
 MESOS_URL = ""
@@ -208,8 +209,8 @@ STATS_MESOS_022 = {
 
 def configure_callback(conf):
     mesos_collectd.configure_callback(conf, IS_MASTER, PREFIX, MESOS_CLUSTER,
-                                      MESOS_INSTANCE, MESOS_HOST, MESOS_PORT,
-                                      MESOS_URL, VERBOSE_LOGGING)
+                                      MESOS_INSTANCE, MESOS_PATH, MESOS_HOST,
+                                      MESOS_PORT, MESOS_URL, VERBOSE_LOGGING)
 
 
 def read_callback():

--- a/mesos-slave.py
+++ b/mesos-slave.py
@@ -21,8 +21,9 @@ import mesos_collectd
 
 IS_MASTER = False
 PREFIX = "mesos-slave"
-MESOS_CLUSTER = ""
-MESOS_INSTANCE = ""
+MESOS_CLUSTER = "cluster-0"
+MESOS_INSTANCE = "slave-0"
+MESOS_PATH = "/usr/sbin"
 MESOS_HOST = "localhost"
 MESOS_PORT = 5051
 MESOS_URL = ""
@@ -101,8 +102,8 @@ STATS_MESOS_022 = STATS_MESOS_021.copy()
 
 def configure_callback(conf):
     mesos_collectd.configure_callback(conf, IS_MASTER, PREFIX, MESOS_CLUSTER,
-                                      MESOS_INSTANCE, MESOS_HOST, MESOS_PORT,
-                                      MESOS_URL, VERBOSE_LOGGING)
+                                      MESOS_INSTANCE, MESOS_PATH, MESOS_HOST,
+                                      MESOS_PORT, MESOS_URL, VERBOSE_LOGGING)
 
 
 def read_callback():


### PR DESCRIPTION
Have user set the path to the mesos-master/slave binary in the
configuration files. Fixes bug where path might not be set when collectd
runs (thanks to @linben for finding this). Also set default values for
cluster and instance names.
