### PR TITLE
Change default version of dictionary used on failed versions lookups

### DIFF
--- a/mesos_collectd.py
+++ b/mesos_collectd.py
@@ -25,7 +25,7 @@ def get_stats_string(version):
     elif version == "1.0.0" or version == "1.0.1":
         stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_100.items())
     else:
-        stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_100.items())
+        stats_cur = dict(STATS_MESOS.items() + STATS_MESOS_022.items())
 
     return stats_cur
 


### PR DESCRIPTION
Change the default version of the default Mesos stats dictionary that's
used on a failed version lookup from 1.x to 0.22.x due to some 1.x
metrics potentially not being available in this case (which will result
in an error)