### PR TITLE
fix log condition

### DIFF
--- a/mesos_collectd.py
+++ b/mesos_collectd.py
@@ -312,7 +312,7 @@ def make_api_call(url, conf, context, headers, data):
             if e.code == 401 and conf.get("dcos_url", None) and url.endswith("/acs/api/v1/auth/login"):
                 log_verbose(conf.get("Verbose", False), "INFO: Refreshing DC/OS authentication token.")
                 refresh_dcos_auth_token(conf)
-            elif e.code == 307 and conf.get("dcos_url", None):
+            elif e.code == 307 and not conf.get("dcos_url", None):
                 log_verbose(
                     conf.get("Verbose", False),
                     "INFO: Skipping API call to %s because this master is not the leader (%s)." % (url, e),


### PR DESCRIPTION
```
>>> if None:
...   print("none");
... else:
...   print("not none");
...
not none
```
This will stop polluting the logs with errors like this when customer is running into a multi primary and the agent is not querying the leader.
```
level=error msg="API call failed: (HTTP Error 307: Temporary Redirect) http://localhost:5050/master/frameworks" collectdInstance=monitor-18 plugin=ERROR
```

Signed-off-by: Dani Louca <dlouca@splunk.com>

cc: @asuresh4 @mstumpfx @keitwb 